### PR TITLE
#946 - No longer allow showing login form with `showForm=true` url pa…

### DIFF
--- a/dashboard/src/App.vue
+++ b/dashboard/src/App.vue
@@ -21,7 +21,7 @@ limitations under the License.
         <new-software-version-component role="alert"/>
 
         <div class="overall-container">
-          <pki-app-bootstrap v-if="isPkiAndNeedsToBootstrap" role="alert"/>
+          <pki-app-bootstrap v-if="isPkiAndNeedsToBootstrap || isOAuthOnlyAndNeedsToBootstrap" role="alert"/>
           <loading-container v-else v-bind:is-loading="isLoading" role="presentation">
             <div v-if="!isLoading">
               <header-view v-if="isAuthenticatedUser && !this.$store.state.showUa" role="banner"/>
@@ -80,6 +80,9 @@ limitations under the License.
       },
       isPkiAndNeedsToBootstrap() {
         return this.$store.getters.isPkiAuthenticated && this.$store.getters.config.needToBootstrap;
+      },
+      isOAuthOnlyAndNeedsToBootstrap() {
+        return this.$store.getters.config.oAuthOnly && this.$store.getters.config.needToBootstrap && this.$store.getters.isAuthenticated;
       },
     },
     created() {

--- a/dashboard/src/InceptionConfigurer.js
+++ b/dashboard/src/InceptionConfigurer.js
@@ -19,7 +19,7 @@ import store from './store/store';
 export default {
 
   configure() {
-    if (store.getters.userInfo) {
+    if (store.getters.userInfo && !store.getters.config.needToBootstrap) {
       const projectId = 'Inception';
       const serviceUrl = window.location.origin;
       let authenticator;

--- a/dashboard/src/components/access/Login.vue
+++ b/dashboard/src/components/access/Login.vue
@@ -189,7 +189,7 @@ limitations under the License.
         return (!this.isAutoFilled && (!this.loginFields.username || !this.loginFields.password));
       },
       oAuthOnly() {
-        return this.$store.getters.config.oAuthOnly && this.$route.query.showForm !== 'true';
+        return this.$store.getters.config.oAuthOnly;
       },
     },
     created() {

--- a/dashboard/src/components/access/RequestAccess.vue
+++ b/dashboard/src/components/access/RequestAccess.vue
@@ -25,7 +25,7 @@ limitations under the License.
         </div>
         <ValidationObserver ref="observer" v-slot="{invalid, handleSubmit}" slim>
           <form @submit.prevent="handleSubmit(login)">
-            <div class="card">
+            <div v-if="!oAuthOnly" class="card">
               <div class="card-body p-4">
                 <div class="form-group">
                   <label for="firstName" class="text-primary">* First Name</label>
@@ -130,6 +130,21 @@ limitations under the License.
                 </div>
               </div>
             </div>
+
+            <div v-if="oAuthProviders && oAuthProviders.length > 0" class="card mt-3" data-cy="oAuthProviders">
+              <div class="card-body">
+                <div class="row">
+                  <div v-for="oAuthProvider in oAuthProviders" :key="oAuthProvider.registrationId" class="col-12 mb-3">
+                    <button type="button" class="btn btn-outline-primary w-100"
+                            @click="oAuth2Login(oAuthProvider.registrationId)" aria-label="oAuth authentication link">
+                      <i :class="oAuthProvider.iconClass" aria-hidden="true" class="mr-1 text-info" />
+                      Login via {{ oAuthProvider.clientName }}
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </div>
+
           </form>
         </ValidationObserver>
       </div>
@@ -177,6 +192,7 @@ aria-describedby=
         },
         passwordConfirmation: '',
         createInProgress: false,
+        oAuthProviders: [],
       };
     },
     methods: {
@@ -192,6 +208,9 @@ aria-describedby=
           }
         });
       },
+      oAuth2Login(registrationId) {
+        this.$store.dispatch('oAuth2Login', registrationId);
+      },
       missingRequiredValues() {
         return !this.loginFields.firstName || !this.loginFields.lastName || !this.loginFields.email || !this.loginFields.password;
       },
@@ -201,6 +220,19 @@ aria-describedby=
       isProgressAndRankingEnabled() {
         return this.$store.getters.config.rankingAndProgressViewsEnabled === true || this.$store.getters.config.rankingAndProgressViewsEnabled === 'true';
       },
+    },
+    computed: {
+      oAuthOnly() {
+        return this.$store.getters.config.oAuthOnly;
+      },
+    },
+    created() {
+      if (!this.$store.getters.isPkiAuthenticated) {
+        AccessService.getOAuthProviders()
+          .then((result) => {
+            this.oAuthProviders = result;
+          });
+      }
     },
   };
 </script>

--- a/e2e-tests/cypress/integration/login_spec.js
+++ b/e2e-tests/cypress/integration/login_spec.js
@@ -205,24 +205,6 @@ describe('Login Tests', () => {
       cy.get('[data-cy=oAuthProviders]').should('exist');
       cy.contains('Login via GitLab')
     });
-
-    it('login form is present for oAuthOnly mode when showForm=true', () => {
-      cy.intercept('GET', '/public/config', {oAuthOnly: true}).as('loadConfig');
-      cy.intercept('GET', '/app/oAuthProviders', [{"registrationId":"gitlab","clientName":"GitLab","iconClass":"fab fa-gitlab"}]).as('getOauthProviders')
-
-      cy.visit('/skills-login', {
-        qs: {
-          showForm: 'true',
-        }
-      });
-
-      cy.wait('@loadConfig');
-      cy.wait('@getOauthProviders');
-      cy.get('#username').should('exist')
-      cy.get('#inputPassword').should('exist')
-      cy.get('[data-cy=oAuthProviders]').should('exist');
-      cy.contains('Login via GitLab')
-    });
   }
 
 });

--- a/e2e-tests/cypress/integration/register_root_user_spec.js
+++ b/e2e-tests/cypress/integration/register_root_user_spec.js
@@ -47,6 +47,30 @@ describe('Register Root Users', () => {
     cy.url().should('include', '/progress-and-ranking')
   });
 
+  it('create account form is not shown for oauth only bootstrap', () => {
+    cy.intercept('GET', '/public/config', {
+      oAuthOnly: true,
+      rankingAndProgressViewsEnabled: true,
+      needToBootstrap: true
+    }).as('loadConfig');
+    cy.intercept('GET', '/app/oAuthProviders', [{"registrationId":"gitlab","clientName":"GitLab","iconClass":"fab fa-gitlab"}]).as('getOauthProviders')
+
+    cy.visit('/administrator/');
+
+    cy.wait('@loadConfig');
+    cy.wait('@getOauthProviders');
+    cy.contains('New Root Account')
+
+    cy.get('#firstName').should('not.exist');
+    cy.get('#lastName').should('not.exist');
+    cy.get('#email').should('not.exist');
+    cy.get('#password').should('not.exist');
+    cy.get('#password_confirmation').should('not.exist');
+    cy.contains('Create Account').should('not.exist');
+    cy.get('[data-cy=oAuthProviders]').should('exist');
+    cy.contains('Login via GitLab')
+  });
+
   it('register root user when Progress and Ranking views are disabled', () => {
 
     cy.intercept('GET', '/public/config', (req) => {

--- a/service/src/test/java/skills/controller/CreateAccountControllerSpec.groovy
+++ b/service/src/test/java/skills/controller/CreateAccountControllerSpec.groovy
@@ -1,0 +1,59 @@
+/**
+ * Copyright 2020 SkillTree
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package skills.controller
+
+import skills.auth.AuthMode
+import skills.auth.UserInfo
+import skills.auth.form.CreateAccountController
+import skills.controller.exceptions.ErrorCode
+import skills.controller.exceptions.SkillException
+import spock.lang.Specification
+
+import javax.servlet.http.HttpServletResponse
+
+class CreateAccountControllerSpec extends Specification {
+
+    def "in oAuthOnly mode, throws SkillException if createAccount is called"() {
+
+        when:
+        CreateAccountController createAccountController = new CreateAccountController(oAuthOnly: true)
+
+        UserInfo userInfo = Mock()
+        HttpServletResponse httpServletResponse = Mock()
+        createAccountController.createAppUser(userInfo, httpServletResponse)
+
+        then:
+        SkillException e = thrown(SkillException)
+        e.getMessage() == "Username/Password account creation is disabled for this installation of the SkillTree"
+        e.errorCode == ErrorCode.AccessDenied
+    }
+
+    def "in PKI mode, throws SkillException if createAccount is called"() {
+
+        when:
+        CreateAccountController createAccountController = new CreateAccountController(authMode: AuthMode.PKI)
+
+        UserInfo userInfo = Mock()
+        HttpServletResponse httpServletResponse = Mock()
+        createAccountController.createAppUser(userInfo, httpServletResponse)
+
+        then:
+        SkillException e = thrown(SkillException)
+        e.getMessage() == "Username/Password account creation is disabled for this installation of the SkillTree"
+        e.errorCode == ErrorCode.AccessDenied
+    }
+
+}


### PR DESCRIPTION
…ram when `skills.authorization.oAuthOnly=true`.  Support oauth for root account creation during bootstrap.  Prevent using /createAccount` endpoint when `oAuthOnly=true` or `authMode=PKI`