### PR TITLE
#1244 - need to set different ports for `skills.h2.port` for tests an…

### DIFF
--- a/service/src/test/java/skills/intTests/SameSiteCookieAttrDisabledSpec.groovy
+++ b/service/src/test/java/skills/intTests/SameSiteCookieAttrDisabledSpec.groovy
@@ -22,8 +22,8 @@ import skills.intTests.utils.DefaultIntSpec
 import skills.intTests.utils.SkillsService
 import spock.lang.IgnoreIf
 
-@SpringBootTest(properties = ['skills.config.sameSiteNoneEnabled=false'], webEnvironment=SpringBootTest.WebEnvironment.RANDOM_PORT, classes = SpringBootApp)
-class SameSiteCookieAttrDisabled extends DefaultIntSpec {
+@SpringBootTest(properties = ['skills.config.sameSiteNoneEnabled=false','skills.h2.port=9094'], webEnvironment=SpringBootTest.WebEnvironment.RANDOM_PORT, classes = SpringBootApp)
+class SameSiteCookieAttrDisabledSpec extends DefaultIntSpec {
 
     @IgnoreIf({env["SPRING_PROFILES_ACTIVE"] == "pki" })
     def "SameSite=None attribute is not on the Set-Cookie header" () {

--- a/service/src/test/java/skills/intTests/SameSiteCookieAttrEnabledSpec.groovy
+++ b/service/src/test/java/skills/intTests/SameSiteCookieAttrEnabledSpec.groovy
@@ -22,8 +22,8 @@ import skills.intTests.utils.DefaultIntSpec
 import skills.intTests.utils.SkillsService
 import spock.lang.IgnoreIf
 
-@SpringBootTest(properties = ['skills.config.sameSiteNoneEnabled=true'], webEnvironment=SpringBootTest.WebEnvironment.RANDOM_PORT, classes = SpringBootApp)
-class SameSiteCookieAttrEnabled extends DefaultIntSpec {
+@SpringBootTest(properties = ['skills.config.forceSameSiteNoneCookie=true', 'skills.h2.port=9095'], webEnvironment=SpringBootTest.WebEnvironment.RANDOM_PORT, classes = SpringBootApp)
+class SameSiteCookieAttrEnabledSpec extends DefaultIntSpec {
 
     @IgnoreIf({env["SPRING_PROFILES_ACTIVE"] == "pki" })
     def "SameSite=None attribute is on the Set-Cookie header" () {

--- a/service/src/test/java/skills/intTests/utils/TransactionHelper.groovy
+++ b/service/src/test/java/skills/intTests/utils/TransactionHelper.groovy
@@ -1,5 +1,19 @@
 package skills.intTests.utils
-
+/**
+ * Copyright 2022 SkillTree
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
 

--- a/service/src/test/java/skills/services/EnableCallStackProfSpec.groovy
+++ b/service/src/test/java/skills/services/EnableCallStackProfSpec.groovy
@@ -24,7 +24,7 @@ import skills.profile.CallStackProfAspect
 import skills.utils.LoggerHelper
 import spock.lang.Specification
 
-@SpringBootTest(properties = ['skills.prof.endpoints.slowMethod2=2000'],
+@SpringBootTest(properties = ['skills.prof.endpoints.slowMethod2=2000', 'skills.h2.port=9093'],
         webEnvironment=SpringBootTest.WebEnvironment.RANDOM_PORT, classes = SpringBootApp)
 class EnableCallStackProfSpec extends Specification {
 


### PR DESCRIPTION
…notated with `@SpringBootTest`, added Spec suffix to SameSiteCookieAttrDisabledSpec and SameSiteCookieAttrEnabledSpec