### PR TITLE
#2947 Add handling for forced colors

### DIFF
--- a/dashboard/src/App.vue
+++ b/dashboard/src/App.vue
@@ -229,4 +229,10 @@ body .st-dark-theme a:visited {
 body a:hover, body a:focus {
   text-decoration: underline !important;
 }
+
+@media (forced-colors: active) {
+  :focus {
+    outline: 2px solid transparent;
+  }
+}
 </style>


### PR DESCRIPTION
This can be tested in Chrome by using the Rendering view in Devtools.

1. Open DevTools
2. Hit CTRL+SHIFT+P
3. Search "render"
4. Click "Show Rendering"
5. In the Rendering draw, scroll to "Emulate CSS media feature forced-colors" and set to `forced-colors: active`
6. Tab around the application to verify the highlighting is still there