### PR TITLE
#3095(fix): added missing version tag, with the latest onwards

### DIFF
--- a/dashboard/pom.xml
+++ b/dashboard/pom.xml
@@ -169,6 +169,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
+                <version>[3.5.0,)</version>
                 <executions>
                     <execution>
                         <id>exec-npm-install</id>


### PR DESCRIPTION
The fix was the one line in the single commit. 

The normal bracket means the latest version will always be resolved, with the minimum version of `3.5.0`