### PR TITLE
Fix for preventing redirect loops for SAML2 redirect

### DIFF
--- a/dashboard/src/router/UseGlobalNavGuards.js
+++ b/dashboard/src/router/UseGlobalNavGuards.js
@@ -131,6 +131,7 @@ export const useGlobalNavGuards = () => {
           		newRoute.name = getLandingPage();
 	          } else if (isSaml2()) {
                 window.location = `/saml2/authenticate/${registrationId()}`;
+                return;
               } else {
 	            newRoute.name = 'Login';
 	          }


### PR DESCRIPTION
For SAML2 login we are using window.location in Vue router guard.  To prevent redirect loops added return statement after window.location in UseGlobalNavGuard.js