### PR TITLE
T#3187 Upgrade Springboot versionto fix the high severity CVE from netty

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
         <guava.version>29.0-jre</guava.version>
 
         <!-- !!!!!IMPORTANT!!!!!: when changing the springboot.version property, make sure you also change it in the spring-boot-starter-parent definition -->
-        <springboot.version>3.4.2</springboot.version>
+        <springboot.version>3.4.3</springboot.version>
         <springcloud.version>3.1.1</springcloud.version>
 
         <logback-access.version>2.0.6</logback-access.version>
@@ -55,7 +55,7 @@
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
         <!-- !!!!!IMPORTANT!!!!!: when changing this version make sure to also update springboot.version property -->
-        <version>3.4.2</version>
+        <version>3.4.3</version>
         <relativePath/>
     </parent>
     <repositories>


### PR DESCRIPTION
Issue in https://github.com/NationalSecurityAgency/skills-service/issues/3187


@rmmayo 

Upgrade Springboot version from 3.4.2 to 3.4.3 to fix the **high severity CVE** from netty

Change in both springboot.verison and spring-boot-starter