### PR TITLE
Check end, not start, when deciding whether to use the default end date

### DIFF
--- a/service/src/main/java/skills/utils/TimeRangeFormatterUtil.groovy
+++ b/service/src/main/java/skills/utils/TimeRangeFormatterUtil.groovy
@@ -28,7 +28,7 @@ class TimeRangeFormatterUtil {
     static List<Date> formatTimeRange(String start, String end, Boolean exactTime = true) {
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
         LocalDateTime startDate = start && !start.equalsIgnoreCase("null") ? LocalDateTime.parse(start, formatter) : LocalDateTime.parse(defaultStart, formatter) //start ? format.parse(start) : format.parse(defaultStart)
-        LocalDateTime endDate = end && !start.equalsIgnoreCase("null") ? LocalDateTime.parse(end, formatter) : LocalDateTime.parse(defaultEnd, formatter)
+        LocalDateTime endDate = end && !end.equalsIgnoreCase("null") ? LocalDateTime.parse(end, formatter) : LocalDateTime.parse(defaultEnd, formatter)
 
         if(!exactTime) {
             startDate = startDate.toLocalDate().atTime(LocalTime.MIN)

--- a/service/src/test/java/skills/utils/TimeRangeFormatterUtilSpec.groovy
+++ b/service/src/test/java/skills/utils/TimeRangeFormatterUtilSpec.groovy
@@ -1,0 +1,57 @@
+/**
+ * Copyright 2020 SkillTree
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package skills.utils
+
+import spock.lang.Specification
+
+class TimeRangeFormatterUtilSpec extends Specification {
+
+    def "end date is used when only the end of the range is supplied"() {
+        when:
+        List<Date> range = TimeRangeFormatterUtil.formatTimeRange(start, end)
+
+        then:
+        range[0].toLocalDateTime().toString() == expectedStart
+        range[1].toLocalDateTime().toString() == expectedEnd
+
+        where:
+        start                 | end                   | expectedStart         | expectedEnd
+        null                  | "2024-03-04 05:06:07" | "1900-01-01T00:00"    | "2024-03-04T05:06:07"
+        ""                    | "2024-03-04 05:06:07" | "1900-01-01T00:00"    | "2024-03-04T05:06:07"
+        "null"                | "2024-03-04 05:06:07" | "1900-01-01T00:00"    | "2024-03-04T05:06:07"
+        "2023-01-02 03:04:05" | null                  | "2023-01-02T03:04:05" | "2100-12-31T23:59:59"
+        "2023-01-02 03:04:05" | "null"                | "2023-01-02T03:04:05" | "2100-12-31T23:59:59"
+        "2023-01-02 03:04:05" | "2024-03-04 05:06:07" | "2023-01-02T03:04:05" | "2024-03-04T05:06:07"
+    }
+
+    def "no arguments gives the full default range"() {
+        when:
+        List<Date> range = TimeRangeFormatterUtil.formatTimeRange(null, null)
+
+        then:
+        range[0].toLocalDateTime().toString() == "1900-01-01T00:00"
+        range[1].toLocalDateTime().toString() == "2100-12-31T23:59:59"
+    }
+
+    def "the inexact range covers whole days"() {
+        when:
+        List<Date> range = TimeRangeFormatterUtil.formatTimeRange(null, "2024-03-04 05:06:07", false)
+
+        then:
+        range[0].toLocalDateTime().toLocalTime() == java.time.LocalTime.MIN
+        range[1].toLocalDateTime().toLocalDate().toString() == "2024-03-04"
+    }
+}


### PR DESCRIPTION
`TimeRangeFormatterUtil.formatTimeRange` decides whether to use the default end date by looking at `start`:

```groovy
LocalDateTime endDate = end && !start.equalsIgnoreCase("null") ? LocalDateTime.parse(end, formatter) : ...
```

The `startDate` line above it reads `start`, so this looks like a copy-paste that kept the wrong variable. `startDate` and `endDate` are both `@RequestParam(required = false)` on the quiz and metrics endpoints in `QuizController`, `AppController`, `NumberUsersPerTagMetricsBuilder` and `OverallNumberUsersPerTagMetricsBuilder`, so all three of the following are reachable from a request.

Running the current class over the argument pairs:

```
start=null                 end=2024-03-04 05:06:07  -> NullPointerException: Cannot invoke method equalsIgnoreCase() on null object
start="null"               end=2024-03-04 05:06:07  -> 1900-01-01T00:00 .. 2100-12-31T23:59:59
start=2023-01-02 03:04:05  end="null"               -> DateTimeParseException: Text 'null' could not be parsed at index 0
```

The first is the common one: sending `endDate` without `startDate` throws, because the short circuit that keeps the `startDate` line safe when `start` is null does not help on the `endDate` line. The second quietly widens the range to the year 2100 rather than honouring the end the caller asked for. The third is the guard failing to do the job it was added for, since it never looks at `end`.

With `end` in the condition, the same pairs give:

```
start=null                 end=2024-03-04 05:06:07  -> 1900-01-01T00:00 .. 2024-03-04T05:06:07
start="null"               end=2024-03-04 05:06:07  -> 1900-01-01T00:00 .. 2024-03-04T05:06:07
start=2023-01-02 03:04:05  end="null"               -> 2023-01-02T03:04:05 .. 2100-12-31T23:59:59
```

The new spec covers both arguments across null, empty, the literal `"null"` and a real date, plus the `exactTime = false` path. `mvn -pl service -am -Dtest=TimeRangeFormatterUtilSpec test` gives 9 tests, 0 failures.
