### PR TITLE
#4018: when running as skills-client (embedded iframe), add the skill…

### DIFF
--- a/dashboard/src/router/index.js
+++ b/dashboard/src/router/index.js
@@ -110,7 +110,7 @@ const redirectToSkillsDisplayIfRequested = (to) => {
       query: { skillsClientDisplayPath: to.path },
     }
   }
-  return true
+  return to.name === 'NotFoundPage' ? true : { name: 'NotFoundPage' };
 }
 
 const routes = [

--- a/dashboard/src/router/index.js
+++ b/dashboard/src/router/index.js
@@ -103,6 +103,16 @@ import TaggedSkills from "@/components/skills/tags/TaggedSkills.vue";
 
 const FullDependencyGraph = defineAsyncComponent(() => import('@/components/skills/dependencies/FullDependencyGraph.vue'))
 
+const redirectToSkillsDisplayIfRequested = (to) => {
+  if (to.query.skillsClientDisplayHostPath) {
+    return {
+      path: to.query.skillsClientDisplayHostPath,
+      query: { skillsClientDisplayPath: to.path },
+    }
+  }
+  return true
+}
+
 const routes = [
   {
     path: '/',
@@ -964,6 +974,9 @@ const routes = [
     path: '/not-found',
     name: 'NotFoundPage',
     component: NotFoundPage,
+    beforeEnter: (to, from) => {
+      return redirectToSkillsDisplayIfRequested(to)
+    },
     props: true,
     meta: {
       requiresAuth: false,
@@ -974,8 +987,9 @@ const routes = [
   },
   { path: '/:pathMatch(.*)*',
     name: '404',
-    redirect: {
-      name: 'NotFoundPage',
+    component: NotFoundPage,
+    beforeEnter: (to, from) => {
+      return redirectToSkillsDisplayIfRequested(to)
     },
     meta: {
       requiresAuth: false,
@@ -1065,6 +1079,70 @@ const constructRouter = () => {
   })
 
   if (isSkillsClient) {
+    const originalResolve = router.resolve;
+
+    router.resolve = function (to, currentLocation) {
+      // Call the original resolver to get the baseline Route Location object
+      const resolved = originalResolve.call(this, to, currentLocation);
+
+      const paramKey = 'skillsClientDisplayHostPath';
+      const isClientDisplayPath = (path) => path?.startsWith(SkillsClientPath.RootUrl);
+      const resolveHostPath = () => {
+        try {
+          if (window.parent && window.parent !== window) {
+            const parentPath = window.parent.location.pathname;
+            if (parentPath && !isClientDisplayPath(parentPath)) {
+              return parentPath;
+            }
+          }
+        } catch {
+          // Parent access can fail in some browser/test contexts.
+        }
+
+        try {
+          if (document.referrer) {
+            const referrerPath = new URL(document.referrer).pathname;
+            if (referrerPath && !isClientDisplayPath(referrerPath)) {
+              return referrerPath;
+            }
+          }
+        } catch {
+          // Ignore malformed referrer.
+        }
+
+        if (resolved.query[paramKey] && !isClientDisplayPath(resolved.query[paramKey])) {
+          return resolved.query[paramKey];
+        }
+
+        log.warn(`unable to determine ${paramKey}`)
+        return null;
+      };
+
+      const paramValue = resolveHostPath();
+      if (paramValue && resolved.query[paramKey] !== paramValue) {
+        const newQuery = {
+          ...resolved.query,
+          [paramKey]: paramValue
+        };
+
+        // `to` can be either a string path or an object; normalize before re-resolving.
+        const locationWithQuery = typeof to === 'string'
+          ? {
+            path: resolved.path,
+            hash: resolved.hash,
+            query: newQuery,
+          }
+          : {
+            ...to,
+            query: newQuery,
+          };
+
+        // Re-resolve with the updated query to correctly regenerate the full href string.
+        return originalResolve.call(this, locationWithQuery, currentLocation);
+      }
+      return resolved;
+    };
+
     router.push('/')
   }
 

--- a/e2e-tests/cypress/e2e/client-display/skills-display-navigation-in-skills-client_spec.js
+++ b/e2e-tests/cypress/e2e/client-display/skills-display-navigation-in-skills-client_spec.js
@@ -139,6 +139,48 @@ describe('Navigation in skills-client tests', () => {
     cy.wrapIframe().find('[data-cy="myRankPosition"]')
   })
 
+  it('breadcrumb links preserve the host path for new-tab navigation', () => {
+    cy.createProject(1)
+    cy.createSubject(1, 1)
+    cy.createSkill(1, 1,1 )
+    cy.createSkill(1, 1,2 )
+
+    cy.visit('/test-skills-client/proj1?skillsClientDisplayPath=%2Fsubjects%2Fsubj1%2Fskills%2Fskill1')
+    cy.wrapIframe().find('[data-cy="skillsDisplayBreadcrumbBar"] [data-cy="breadcrumbLink-subj1"]').then(($link) => {
+      const href = $link.attr('href')
+      expect(href).to.include('/subjects/subj1')
+      expect(new URL(href, 'http://localhost').searchParams.get('skillsClientDisplayHostPath')).to.eq('/test-skills-client/proj1')
+    })
+  })
+
+  it('subject page skill links preserve the host path for new-tab navigation', () => {
+    cy.createProject(1)
+    cy.createSubject(1, 1)
+    cy.createSkill(1, 1,1 )
+    cy.createSkill(1, 1,2 )
+
+    cy.visit('/test-skills-client/proj1?skillsClientDisplayPath=%2Fsubjects%2Fsubj1')
+    cy.wrapIframe().find('[data-cy="skillProgressTitle"]').first().then(($link) => {
+      const href = $link.attr('href')
+      expect(href).to.include('/subjects/subj1/skills/skill1')
+      expect(new URL(href, 'http://localhost').searchParams.get('skillsClientDisplayHostPath')).to.eq('/test-skills-client/proj1')
+    })
+  })
+
+  it('rank page links preserve the host path for new-tab navigation', () => {
+    cy.createProject(1)
+    cy.createSubject(1, 1)
+    cy.createSkill(1, 1,1 )
+    cy.createSkill(1, 1,2 )
+
+    cy.visit('/test-skills-client/proj1?skillsClientDisplayPath=%2Fsubjects%2Fsubj1%2Frank')
+    cy.wrapIframe().find('[data-cy="skillsDisplayBreadcrumbBar"] [data-cy="breadcrumbLink-Overview"]').then(($link) => {
+      const href = $link.attr('href')
+      expect(href).to.include('/?')
+      expect(new URL(href, 'http://localhost').searchParams.get('skillsClientDisplayHostPath')).to.eq('/test-skills-client/proj1')
+    })
+  })
+
   it('deep link into various pages', () => {
     cy.createProject(1)
     cy.createSubject(1, 1)


### PR DESCRIPTION
…sClientDisplayHostPath query param to all router links so that links can be copied and or right-clicked and opened in new tab/window